### PR TITLE
Make ACK optional

### DIFF
--- a/lib/mllp/ack.ex
+++ b/lib/mllp/ack.ex
@@ -38,12 +38,18 @@ defmodule MLLP.Ack do
     msa = ["MSA", "AR", message_control_id, "Message was not parsable as HL7"]
 
     HL7.Message.new([msh, msa]) |> to_string()
-
   end
 
   defp make_ack_hl7(message, code, text_message) do
     hl7 = message |> HL7.Message.new()
-    %HL7.Header{receiving_application: receiving_application, receiving_facility: receiving_facility, sending_application: sending_application, sending_facility: sending_facility, message_control_id: message_control_id} = hl7.header
+
+    %HL7.Header{
+      receiving_application: receiving_application,
+      receiving_facility: receiving_facility,
+      sending_application: sending_application,
+      sending_facility: sending_facility,
+      message_control_id: message_control_id
+    } = hl7.header
 
     msh =
       hl7
@@ -60,7 +66,6 @@ defmodule MLLP.Ack do
   end
 
   def verify_ack_against_message(%HL7.Message{} = message, %HL7.Message{} = ack) do
-
     message_hl7 = message |> HL7.Message.new()
     message_header = message_hl7.header
     ack_msa = ack |> HL7.Message.new() |> HL7.Message.find("MSA")
@@ -70,7 +75,6 @@ defmodule MLLP.Ack do
     ack_result = ack_msa |> HL7.Segment.get_part(1)
 
     if String.contains?(ack_message_control_id, message_control_id) do
-
       case ack_result do
         "AA" ->
           {:ok, :application_accept}

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -129,7 +129,7 @@ defmodule MLLP.Receiver do
            <<"MSH", _::binary>> = message,
            socket_reply_fun,
            dispatcher_module,
-           ack
+           ack \\ true
          ) do
       result = apply(dispatcher_module, :dispatch, [message])
       if ack do

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -138,6 +138,12 @@ defmodule MLLP.Receiver do
     end
 
     defp process_message(
+           _junk_message,
+           socket_reply_fun,
+           _dispatcher_module,
+           _ack \\ true
+        ) 
+    defp process_message(
            <<"MSH", _::binary>> = message,
            socket_reply_fun,
            dispatcher_module,

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -138,12 +138,6 @@ defmodule MLLP.Receiver do
     end
 
     defp process_message(
-           _junk_message,
-           socket_reply_fun,
-           _dispatcher_module,
-           _ack \\ true
-        ) 
-    defp process_message(
            <<"MSH", _::binary>> = message,
            socket_reply_fun,
            dispatcher_module,

--- a/lib/mllp/sender.ex
+++ b/lib/mllp/sender.ex
@@ -37,26 +37,31 @@ defmodule MLLP.Sender do
   end
 
   ## GenServer callbacks
+  @impl true
   def init({ip_address, port}) do
     state = attempt_connection(%State{ip_address: ip_address, port: port})
     {:ok, state}
   end
 
-  def handle_cast({:send, _message}, _from, %State{socket: nil} = state) do
+  @impl true
+  def handle_cast({:send, _message}, %State{socket: nil} = state) do
     log_message(state, "cannot send to nil socket")
     {:noreply, state}
   end
 
-  def handle_cast({:send, message}, _from, state) do
+  @impl true
+  def handle_cast({:send, message}, state) do
     :gen_tcp.send(state.socket, message)
     {:noreply, state}
   end
 
+  @impl true
   def handle_call({:send, _message}, _from, %State{socket: nil} = state) do
     log_message(state, "cannot send to nil socket")
     {:reply, {:ok, :application_error}, state}
   end
 
+  @impl true
   def handle_call({:send, message}, _from, state) do
     :gen_tcp.send(state.socket, message)
     |> case do
@@ -72,15 +77,18 @@ defmodule MLLP.Sender do
     end
   end
 
+  @impl true
   def handle_call(:get_messages_sent_count, _reply, state) do
     {:reply, state.messages_sent, state}
   end
 
+  @impl true
   def handle_info({:tcp_closed, _socket}, state) do
     new_state = maintain_reconnect_timer(state)
     {:noreply, new_state}
   end
 
+  @impl true
   def handle_info(:timeout, state) do
     new_state =
       %State{state | pending_reconnect: nil}
@@ -89,6 +97,7 @@ defmodule MLLP.Sender do
     {:noreply, new_state}
   end
 
+  @impl true
   def terminate(_reason, state) do
     log_message(state, "stopping sender")
 

--- a/test/receiver_test.exs
+++ b/test/receiver_test.exs
@@ -65,5 +65,4 @@ defmodule ReceiverTest do
 
     assert {"", ["MSH|blah"]} == Receiver.extract_messages(payload)
   end
-
 end

--- a/test/receiver_test.exs
+++ b/test/receiver_test.exs
@@ -14,6 +14,9 @@ defmodule ReceiverTest do
     refute Process.alive?(pid)
   end
 
+  test "Receive don't send ack message back" do
+
+  end
   test "Receiver returns application_error on junk payload" do
     echo_fun = fn msg -> msg end
 

--- a/test/receiver_test.exs
+++ b/test/receiver_test.exs
@@ -14,9 +14,6 @@ defmodule ReceiverTest do
     refute Process.alive?(pid)
   end
 
-  test "Receive don't send ack message back" do
-
-  end
   test "Receiver returns application_error on junk payload" do
     echo_fun = fn msg -> msg end
 

--- a/test/receiver_test.exs
+++ b/test/receiver_test.exs
@@ -17,7 +17,7 @@ defmodule ReceiverTest do
   test "Receiver returns application_error on junk payload" do
     echo_fun = fn msg -> msg end
 
-    reply = MLLP.Receiver.process_message("JUNK!!!", echo_fun, MLLP.Dispatcher)
+    reply = MLLP.Receiver.process_message("JUNK!!!", echo_fun, MLLP.Dispatcher, true)
 
     ack_hl7 =
       reply

--- a/test/sender_test.exs
+++ b/test/sender_test.exs
@@ -20,6 +20,16 @@ defmodule SenderTest do
     refute Process.alive?(pid)
   end
 
+  test "Integration: sending valid HL7 with without ACK" do
+    port = 8131
+    {:ok, %{pid: pid}} = Receiver.start(port, SenderTest.TestDispatcher, false)
+    {:ok, sender_pid} = Sender.start_link({{127, 0, 0, 1}, port})
+    hl7 = HL7.Examples.wikipedia_sample_hl7()
+    assert Sender.async_send_message(sender_pid, hl7) == :ok
+    :ok = MLLP.Receiver.stop(port)
+    refute Process.alive?(pid)
+  end
+
   test "Integration: sending valid HL7 with no receiver" do
     port = 8131
 


### PR DESCRIPTION
In some case, the client don't want to receive ACK message. So, It's better we could make ACK optional for server.

Run mix test passed
Finished in 0.2 seconds
6 doctests, 30 tests, 0 failures