### PR TITLE
Add additional flags to dialyzer config

### DIFF
--- a/lib/mllp/sender.ex
+++ b/lib/mllp/sender.ex
@@ -210,8 +210,8 @@ defmodule MLLP.Sender do
   end
 
   def handle_call(:reconnect, _from, state) do
-    stop_connection(state, nil, "reconnect command")
-    {:reply, :ok, state}
+    state1 = stop_connection(state, nil, "reconnect command")
+    {:reply, :ok, state1}
   end
 
   def handle_call(_, _from, %State{socket: nil} = state) do
@@ -357,7 +357,7 @@ defmodule MLLP.Sender do
   defp ensure_pending_reconnect_cancelled(%{pending_reconnect: nil} = state), do: state
 
   defp ensure_pending_reconnect_cancelled(state) do
-    Process.cancel_timer(state.pending_reconnect)
+    :ok = Process.cancel_timer(state.pending_reconnect, async: true)
     %{state | pending_reconnect: nil}
   end
 
@@ -373,7 +373,7 @@ defmodule MLLP.Sender do
     |> case do
       {:ok, socket} ->
         if state.pending_reconnect != nil do
-          Process.cancel_timer(state.pending_reconnect)
+          :ok = Process.cancel_timer(state.pending_reconnect, async: true)
         end
 
         telemetry(:status, %{status: :connected}, state)

--- a/lib/mllp/sender.ex
+++ b/lib/mllp/sender.ex
@@ -357,7 +357,7 @@ defmodule MLLP.Sender do
   defp ensure_pending_reconnect_cancelled(%{pending_reconnect: nil} = state), do: state
 
   defp ensure_pending_reconnect_cancelled(state) do
-    :ok = Process.cancel_timer(state.pending_reconnect, async: true)
+    :ok = Process.cancel_timer(state.pending_reconnect, info: false)
     %{state | pending_reconnect: nil}
   end
 
@@ -373,7 +373,7 @@ defmodule MLLP.Sender do
     |> case do
       {:ok, socket} ->
         if state.pending_reconnect != nil do
-          :ok = Process.cancel_timer(state.pending_reconnect, async: true)
+          :ok = Process.cancel_timer(state.pending_reconnect, info: false)
         end
 
         telemetry(:status, %{status: :connected}, state)

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule MLLP.MixProject do
     [
       remove_defaults: [:unknown],
       plt_core_path: "priv/plts",
-      flags: [:unknown],
+      flags: [:race_conditions, :unmatched_returns, :unknown],
       plt_file: {:no_warn, "priv/plts/mllp.plt"}
     ]
   end


### PR DESCRIPTION
This commit adds :unmatched_returns and :race_conditions to dialzyer config.

See https://www.erlang.org/doc/man/dialyzer.html for details

- changed lib/mllp/sender.ex to cancel timer asynchronously