### PR TITLE
Remove MLLP.Receiver.start/0

### DIFF
--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -60,7 +60,7 @@ defmodule MLLP.Receiver do
 
   @spec start(options()) :: {:ok, map()} | {:error, any()}
 
-  def start(opts \\ []) do
+  def start(opts) do
     args = to_args(opts)
 
     result =


### PR DESCRIPTION
- Removed start/0 since options are mandatory now

Closes #28 