### PR TITLE
Downgraded ranch version to 1.8.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule MLLP.MixProject do
   defp deps do
     [
       {:telemetry, "~> 0.4.3"},
-      {:ranch, "~> 2.1.0"},
+      {:ranch, "~> 1.8.0"},
       {:elixir_hl7, "~> 0.6.0"},
       {:ex_doc, "~> 0.24.2", only: :dev, runtime: false},
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "mox": {:hex, :mox, "1.0.0", "4b3c7005173f47ff30641ba044eb0fe67287743eec9bd9545e37f3002b0a9f8b", [:mix], [], "hexpm", "201b0a20b7abdaaab083e9cf97884950f8a30a1350a1da403b3145e213c6f4df"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.0", "b44d75e2a6542dcb6acf5d71c32c74ca88960421b6874777f79153bbbbd7dccc", [:mix], [], "hexpm", "52b2871a7515a5ac49b00f214e4165a40724cf99798d8e4a65e4fd64ebd002c1"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ranch": {:hex, :ranch, "2.1.0", "2261f9ed9574dcfcc444106b9f6da155e6e540b2f82ba3d42b339b93673b72a3", [:make, :rebar3], [], "hexpm", "244ee3fa2a6175270d8e1fc59024fd9dbc76294a321057de8f803b1479e76916"},
+  "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},

--- a/test/receiver_test.exs
+++ b/test/receiver_test.exs
@@ -59,7 +59,7 @@ defmodule ReceiverTest do
       {:ok, _} = Receiver.start(port: port, dispatcher: MLLP.EchoDispatcher)
 
       assert capture_log(fn -> Receiver.start(port: port, dispatcher: MLLP.EchoDispatcher) end) =~
-               "port: 8132]}) for reason :eaddrinuse (address already in use)"
+               "port: 8132]) for reason :eaddrinuse (address already in use)"
     end
   end
 

--- a/test/sender_and_receiver_integration_test.exs
+++ b/test/sender_and_receiver_integration_test.exs
@@ -38,9 +38,9 @@ defmodule SenderAndReceiverIntegrationTest do
       ]
 
       expected_spec = %{
-        id: {:ranch_embedded_sup, ReceiverSupervisionTest},
+        id: {:ranch_listener_sup, ReceiverSupervisionTest},
         start:
-          {:ranch_embedded_sup, :start_link,
+          {:ranch_listener_sup, :start_link,
            [
              ReceiverSupervisionTest,
              :ranch_tcp,
@@ -55,7 +55,10 @@ defmodule SenderAndReceiverIntegrationTest do
                dispatcher_module: MLLP.EchoDispatcher
              ]
            ]},
-        type: :supervisor
+        type: :supervisor,
+        modules: [:ranch_listener_sup],
+        restart: :permanent,
+        shutdown: :infinity
       }
 
       assert MLLP.Receiver.child_spec(opts) == expected_spec


### PR DESCRIPTION
Downgrading `ranch` dependency to 1.8. Some app fails to run due to dependency on 1.8 version due to `cowboy`. 

Testing instructions:
Follow README section Using TLS

