### PR TITLE
Added client ip restrictions

### DIFF
--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -365,7 +365,7 @@ defmodule MLLP.Receiver do
     |> String.to_charlist()
     |> :inet.gethostbyname()
     |> case do
-      {:ok, {:hostent, _, _, _, _, [address]}} ->
+      {:ok, {:hostent, _, _, _, _, [address | _]}} ->
         address
 
       error ->

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -350,14 +350,27 @@ defmodule MLLP.Receiver do
   defp normalize_ip(ip) when is_binary(ip) do
     ip
     |> String.to_charlist()
-    |> :inet.getaddr(:inet)
+    |> :inet.parse_address()
     |> case do
       {:ok, address} ->
         address
 
+      _ ->
+        normalize_hostname(ip)
+    end
+  end
+
+  defp normalize_hostname(name) do
+    name
+    |> String.to_charlist()
+    |> :inet.gethostbyname()
+    |> case do
+      {:ok, {:hostent, _, _, _, _, [address]}} ->
+        address
+
       error ->
         Logger.warn(
-          "IP #{inspect(ip)} provided is not a valid IP #{inspect(error)}, filtering this IP"
+          "IP/hostname #{inspect(name)} provided is not a valid IP/hostname #{inspect(error)}. It will be filtered from allowed_client_ips list"
         )
 
         nil

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -344,10 +344,11 @@ defmodule MLLP.Receiver do
     end
   end
 
-  defp normalize_ip({_, _, _, _} = ip), do: ip
-  defp normalize_ip({_, _, _, _, _, _, _, _} = ip), do: ip
+  def normalize_ip({_, _, _, _} = ip), do: ip
+  def normalize_ip({_, _, _, _, _, _, _, _} = ip), do: ip
+  def normalize_ip(ip) when is_atom(ip), do: normalize_ip(to_string(ip))
 
-  defp normalize_ip(ip) when is_binary(ip) do
+  def normalize_ip(ip) when is_binary(ip) do
     ip
     |> String.to_charlist()
     |> :inet.parse_address()

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -118,7 +118,7 @@ defmodule MLLP.Receiver do
           :ranch_tcp,
           %{socket_opts: [port: 4090], num_acceptors: 100, max_connections: 20_000},
           MLLP.Receiver,
-          [packet_framer_module: MLLP.DefaultPacketFramer, dispatcher_module: MLLP.EchoDispatcher]
+          [packet_framer_module: MLLP.DefaultPacketFramer, dispatcher_module: MLLP.EchoDispatcher, allowed_client_ips: []]
         ]},
         type: :supervisor,
         modules: [:ranch_listener_sup],
@@ -192,8 +192,18 @@ defmodule MLLP.Receiver do
       |> Map.merge(Keyword.get(opts, :transport_opts, %{}))
       |> update_transport_options(port)
 
+    allowed_client_ips =
+      Keyword.get(opts, :allowed_client_ips, [])
+      |> Enum.map(&normalize_ip/1)
+      |> Enum.reject(&is_nil(&1))
+
     proto_mod = __MODULE__
-    proto_opts = [packet_framer_module: packet_framer_mod, dispatcher_module: dispatcher_mod]
+
+    proto_opts = [
+      packet_framer_module: packet_framer_mod,
+      dispatcher_module: dispatcher_mod,
+      allowed_client_ips: allowed_client_ips
+    ]
 
     %{
       receiver_id: receiver_id,
@@ -263,21 +273,26 @@ defmodule MLLP.Receiver do
     {:ok, server_info} = transport.sockname(socket)
     {:ok, client_info} = transport.peername(socket)
 
-    :ok = transport.setopts(socket, active: :once)
+    if allow_client_ip(client_info, Keyword.get(options, :allowed_client_ips, [])) do
+      :ok = transport.setopts(socket, active: :once)
 
-    state = %{
-      socket: socket,
-      server_info: server_info,
-      client_info: client_info,
-      transport: transport,
-      framing_context: %FramingContext{
-        packet_framer_module: Keyword.get(options, :packet_framer_module),
-        dispatcher_module: Keyword.get(options, :dispatcher_module)
+      state = %{
+        socket: socket,
+        server_info: server_info,
+        client_info: client_info,
+        transport: transport,
+        framing_context: %FramingContext{
+          packet_framer_module: Keyword.get(options, :packet_framer_module),
+          dispatcher_module: Keyword.get(options, :dispatcher_module)
+        }
       }
-    }
 
-    # http://erlang.org/doc/man/gen_server.html#enter_loop-3
-    :gen_server.enter_loop(__MODULE__, [], state)
+      # http://erlang.org/doc/man/gen_server.html#enter_loop-3
+      :gen_server.enter_loop(__MODULE__, [], state)
+    else
+      Logger.warn("Unexpected client #{inspect(client_info)} is attempting to connect")
+      {:stop, %{message: "Client with IP #{inspect(client_info)} is not allowed to connect."}}
+    end
   end
 
   def handle_info({message, socket, data}, state) when message in [:tcp, :ssl] do
@@ -327,5 +342,31 @@ defmodule MLLP.Receiver do
     else
       framing_context2
     end
+  end
+
+  defp normalize_ip({_, _, _, _} = ip), do: ip
+  defp normalize_ip({_, _, _, _, _, _, _, _} = ip), do: ip
+
+  defp normalize_ip(ip) when is_binary(ip) do
+    ip
+    |> String.to_charlist()
+    |> :inet.getaddr(:inet)
+    |> case do
+      {:ok, address} ->
+        address
+
+      error ->
+        Logger.warn(
+          "IP #{inspect(ip)} provided is not a valid IP #{inspect(error)}, filtering this IP"
+        )
+
+        nil
+    end
+  end
+
+  defp allow_client_ip({_ip, _port}, []), do: true
+
+  defp allow_client_ip({ip, _port}, allowed_client_ips) do
+    ip in allowed_client_ips
   end
 end

--- a/test/sender_and_receiver_integration_test.exs
+++ b/test/sender_and_receiver_integration_test.exs
@@ -15,10 +15,10 @@ defmodule SenderAndReceiverIntegrationTest do
     }
 
     transport_opts = ctx[:transport_opts] || %{}
-    allowed_client_ips = ctx[:allowed_client_ips] || []
+    allowed_clients = ctx[:allowed_clients] || []
     port = ctx[:port] || 9000
 
-    [ack: ack, port: port, transport_opts: transport_opts, allowed_client_ips: allowed_client_ips]
+    [ack: ack, port: port, transport_opts: transport_opts, allowed_clients: allowed_clients]
   end
 
   describe "Supervsion" do
@@ -71,7 +71,7 @@ defmodule SenderAndReceiverIntegrationTest do
              [
                packet_framer_module: MLLP.DefaultPacketFramer,
                dispatcher_module: MLLP.EchoDispatcher,
-               allowed_client_ips: []
+               allowed_clients: []
              ]
            ]},
         type: :supervisor,
@@ -304,13 +304,13 @@ defmodule SenderAndReceiverIntegrationTest do
           port: ctx.port,
           dispatcher: MLLP.EchoDispatcher,
           transport_opts: ctx.transport_opts,
-          allowed_client_ips: ctx.allowed_client_ips
+          allowed_clients: ctx.allowed_clients
         )
 
       on_exit(fn -> MLLP.Receiver.stop(ctx.port) end)
     end
 
-    @tag allowed_client_ips: ["127.0.0.0"]
+    @tag allowed_clients: ["127.0.0.0"]
     test "can restrict client if client IP is not allowed", ctx do
       {:ok, sender_pid} = MLLP.Sender.start_link("localhost", ctx.port)
 
@@ -321,7 +321,7 @@ defmodule SenderAndReceiverIntegrationTest do
                )
     end
 
-    @tag allowed_client_ips: ["127.0.0.0", "localhost"]
+    @tag allowed_clients: ["127.0.0.0", "localhost"]
     test "allow connection from allowed client ips", ctx do
       {:ok, sender_pid} = MLLP.Sender.start_link("localhost", ctx.port)
 

--- a/test/sender_and_receiver_integration_test.exs
+++ b/test/sender_and_receiver_integration_test.exs
@@ -261,6 +261,7 @@ defmodule SenderAndReceiverIntegrationTest do
     end
 
     @tag :tls
+    @tag port: 8154
     test "can send to tls receiver", ctx do
       {:ok, sender_pid} =
         MLLP.Sender.start_link("localhost", ctx.port, tls: ctx.sender_tls_options)
@@ -273,6 +274,7 @@ defmodule SenderAndReceiverIntegrationTest do
     end
 
     @tag :tls
+    @tag port: 8155
     test "fails to connect to tls receiver with host name verification failure", ctx do
       {:ok, sender_pid} =
         MLLP.Sender.start_link({127, 0, 0, 1}, ctx.port, tls: ctx.sender_tls_options)
@@ -285,6 +287,7 @@ defmodule SenderAndReceiverIntegrationTest do
     end
 
     @tag :tls
+    @tag port: 8156
     test "can send to tls receiver without certificate with verify none option", ctx do
       {:ok, sender_pid} =
         MLLP.Sender.start_link("localhost", ctx.port, tls: [verify: :verify_none])
@@ -311,6 +314,7 @@ defmodule SenderAndReceiverIntegrationTest do
     end
 
     @tag allowed_clients: ["127.0.0.0"]
+    @tag port: 8157
     test "can restrict client if client IP is not allowed", ctx do
       {:ok, sender_pid} = MLLP.Sender.start_link("localhost", ctx.port)
 
@@ -322,7 +326,20 @@ defmodule SenderAndReceiverIntegrationTest do
     end
 
     @tag allowed_clients: ["127.0.0.0", "localhost"]
-    test "allow connection from allowed client ips", ctx do
+    @tag port: 8158
+    test "allow connection from allowed clients", ctx do
+      {:ok, sender_pid} = MLLP.Sender.start_link("localhost", ctx.port)
+
+      assert ctx.ack ==
+               MLLP.Sender.send_hl7_and_receive_ack(
+                 sender_pid,
+                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+               )
+    end
+
+    @tag allowed_clients: [:localhost]
+    @tag port: 8159
+    test "atom is allowed as client ip or dns", ctx do
       {:ok, sender_pid} = MLLP.Sender.start_link("localhost", ctx.port)
 
       assert ctx.ack ==

--- a/test/sender_and_receiver_integration_test.exs
+++ b/test/sender_and_receiver_integration_test.exs
@@ -3,6 +3,24 @@ defmodule SenderAndReceiverIntegrationTest do
   import ExUnit.CaptureLog
   @moduletag capture_log: true
 
+  setup ctx do
+    ack = {
+      :error,
+      :application_reject,
+      %MLLP.Ack{
+        acknowledgement_code: "AR",
+        hl7_ack_message: nil,
+        text_message: "A real MLLP message dispatcher was not provided"
+      }
+    }
+
+    transport_opts = ctx[:transport_opts] || %{}
+    allowed_client_ips = ctx[:allowed_client_ips] || []
+    port = ctx[:port] || 9000
+
+    [ack: ack, port: port, transport_opts: transport_opts, allowed_client_ips: allowed_client_ips]
+  end
+
   describe "Supervsion" do
     test "successfully starts up under a supervisor using a child spec" do
       port = 8999
@@ -52,7 +70,8 @@ defmodule SenderAndReceiverIntegrationTest do
              MLLP.Receiver,
              [
                packet_framer_module: MLLP.DefaultPacketFramer,
-               dispatcher_module: MLLP.EchoDispatcher
+               dispatcher_module: MLLP.EchoDispatcher,
+               allowed_client_ips: []
              ]
            ]},
         type: :supervisor,
@@ -215,8 +234,6 @@ defmodule SenderAndReceiverIntegrationTest do
 
   describe "tls support" do
     setup ctx do
-      port = ctx[:port]
-
       transport_opts = %{
         tls: [
           cacertfile: "tls/root-ca/ca_certificate.pem",
@@ -228,7 +245,7 @@ defmodule SenderAndReceiverIntegrationTest do
 
       {:ok, %{pid: receiver_pid}} =
         MLLP.Receiver.start(
-          port: port,
+          port: ctx.port,
           dispatcher: MLLP.EchoDispatcher,
           transport_opts: transport_opts
         )
@@ -238,21 +255,12 @@ defmodule SenderAndReceiverIntegrationTest do
         cacertfile: "tls/root-ca/ca_certificate.pem"
       ]
 
-      ack = {
-        :error,
-        :application_reject,
-        %MLLP.Ack{
-          acknowledgement_code: "AR",
-          hl7_ack_message: nil,
-          text_message: "A real MLLP message dispatcher was not provided"
-        }
-      }
+      on_exit(fn -> MLLP.Receiver.stop(ctx.port) end)
 
-      [receiver_pid: receiver_pid, sender_tls_options: sender_tls_options, port: port, ack: ack]
+      [receiver_pid: receiver_pid, sender_tls_options: sender_tls_options]
     end
 
     @tag :tls
-    @tag port: 8154
     test "can send to tls receiver", ctx do
       {:ok, sender_pid} =
         MLLP.Sender.start_link("localhost", ctx.port, tls: ctx.sender_tls_options)
@@ -265,7 +273,6 @@ defmodule SenderAndReceiverIntegrationTest do
     end
 
     @tag :tls
-    @tag port: 8155
     test "fails to connect to tls receiver with host name verification failure", ctx do
       {:ok, sender_pid} =
         MLLP.Sender.start_link({127, 0, 0, 1}, ctx.port, tls: ctx.sender_tls_options)
@@ -278,10 +285,45 @@ defmodule SenderAndReceiverIntegrationTest do
     end
 
     @tag :tls
-    @tag port: 8156
     test "can send to tls receiver without certificate with verify none option", ctx do
       {:ok, sender_pid} =
         MLLP.Sender.start_link("localhost", ctx.port, tls: [verify: :verify_none])
+
+      assert ctx.ack ==
+               MLLP.Sender.send_hl7_and_receive_ack(
+                 sender_pid,
+                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+               )
+    end
+  end
+
+  describe "ip restriction" do
+    setup ctx do
+      {:ok, %{pid: _receiver_pid}} =
+        MLLP.Receiver.start(
+          port: ctx.port,
+          dispatcher: MLLP.EchoDispatcher,
+          transport_opts: ctx.transport_opts,
+          allowed_client_ips: ctx.allowed_client_ips
+        )
+
+      on_exit(fn -> MLLP.Receiver.stop(ctx.port) end)
+    end
+
+    @tag allowed_client_ips: ["127.0.0.0"]
+    test "can restrict client if client IP is not allowed", ctx do
+      {:ok, sender_pid} = MLLP.Sender.start_link("localhost", ctx.port)
+
+      assert {:error, %{reason: :closed, type: :recv_failure}} ==
+               MLLP.Sender.send_hl7_and_receive_ack(
+                 sender_pid,
+                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+               )
+    end
+
+    @tag allowed_client_ips: ["127.0.0.0", "localhost"]
+    test "allow connection from allowed client ips", ctx do
+      {:ok, sender_pid} = MLLP.Sender.start_link("localhost", ctx.port)
 
       assert ctx.ack ==
                MLLP.Sender.send_hl7_and_receive_ack(


### PR DESCRIPTION
#31 

Adding client ip restrictions to restrict client from specific list of IPs. When we start listener, we can optionally provide list of IPs from where client connections should be allowed.

Testing instructions:
- By default, as before it will allow all clients
- Start Receiver `MLLP.Receiver.start([port: 9000, dispatcher: MLLP.EchoDispatcher, allowed_client_ips: ["127.0.0.0"]])`
- Start Sender `MLLP.Sender.start_link("localhost", 9000)`
     A warning should appear [warn]  Unexpected client {{127, 0, 0, 1}, 59223} is attempting to connect
- If try to send message using sender pid, MLLP.Sender.send_hl7_and_receive_ack(sender_pid, HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()), will get error `{:error, %{reason: :closed, type: :recv_failure}}`


