### PR TITLE
Update tls.sh

### DIFF
--- a/tls/tls.sh
+++ b/tls/tls.sh
@@ -2,7 +2,7 @@ cd tls
 
 mkdir root-ca client server
 cd root-ca
-rm index.txt
+rm -f index.txt
 touch index.txt
 echo 01 > serial
 mkdir certs private


### PR DESCRIPTION
* Cosmetic fix to silence rm's complaint on the first `mix test`:

$ mix test
...
==> mllp
Compiling 15 files (.ex)
Generated mllp app
rm: cannot remove 'index.txt': No such file or directory
...

* github.com editor added missing newline at end of file.