### PR TITLE
Adjust echo dispatcher to return an ack or nack depending on the validity of a message

### DIFF
--- a/lib/mllp/echo_dispatcher.ex
+++ b/lib/mllp/echo_dispatcher.ex
@@ -12,7 +12,8 @@ defmodule MLLP.EchoDispatcher do
   @spec dispatch(:mllp_hl7 | :mllp_unknown, binary(), MLLP.FramingContext.t()) ::
           {:ok, MLLP.FramingContext.t()}
   def dispatch(:mllp_unknown, _, state) do
-    {:ok, %{state | reply_buffer: "mllp_unknown"}}
+    msg = MLLP.Envelope.wrap_message("mllp_unknown")
+    {:ok, %{state | reply_buffer: msg}}
   end
 
   def dispatch(:mllp_hl7, message, state) when is_binary(message) do

--- a/lib/mllp/echo_dispatcher.ex
+++ b/lib/mllp/echo_dispatcher.ex
@@ -11,9 +11,13 @@ defmodule MLLP.EchoDispatcher do
 
   @spec dispatch(:mllp_hl7 | :mllp_unknown, binary(), MLLP.FramingContext.t()) ::
           {:ok, MLLP.FramingContext.t()}
-  def dispatch(type, message, state) when is_binary(message) do
+  def dispatch(:mllp_unknown, _, state) do
+    {:ok, %{state | reply_buffer: "mllp_unknown"}}
+  end
+
+  def dispatch(:mllp_hl7, message, state) when is_binary(message) do
     Logger.info(
-      "The EchoDispatcher simply logs and discards messages. Message type: #{to_string(type)} Message: #{message}"
+      "The EchoDispatcher simply logs and discards messages. Message type: :mllp_hl7 Message: #{message}"
     )
 
     {:ok, %{state | reply_buffer: reply_for(message)}}

--- a/test/client_and_receiver_integration_test.exs
+++ b/test/client_and_receiver_integration_test.exs
@@ -6,10 +6,10 @@ defmodule ClientAndReceiverIntegrationTest do
 
   setup ctx do
     ack = {
-      :error,
-      :application_reject,
+      :ok,
+      :application_accept,
       %MLLP.Ack{
-        acknowledgement_code: "AR",
+        acknowledgement_code: "AA",
         hl7_ack_message: nil,
         text_message: "A real MLLP message dispatcher was not provided"
       }
@@ -39,7 +39,7 @@ defmodule ClientAndReceiverIntegrationTest do
       {:ok, client_pid} = MLLP.Client.start_link({127, 0, 0, 1}, port)
 
       capture_log(fn ->
-        assert {:error, _, _ack} =
+        assert {:ok, _, _ack} =
                  MLLP.Client.send(
                    client_pid,
                    HL7.Message.new(HL7.Examples.wikipedia_sample_hl7())

--- a/test/echo_dispatcher_test.exs
+++ b/test/echo_dispatcher_test.exs
@@ -3,14 +3,14 @@ defmodule EchoDispatcherTest do
   alias MLLP.EchoDispatcher
   doctest EchoDispatcher
 
-  test "Default dispatcher accepts HL7, logs, and returns application_reject" do
+  test "Echo dispatcher accepts HL7, logs, and returns application_accept" do
     state = %MLLP.FramingContext{}
     message = HL7.Examples.wikipedia_sample_hl7()
 
     expected_reply =
       MLLP.Ack.get_ack_for_message(
         message,
-        :application_reject,
+        :application_accept,
         "A real MLLP message dispatcher was not provided"
       )
       |> to_string()
@@ -19,5 +19,23 @@ defmodule EchoDispatcherTest do
     expected_state = %{state | reply_buffer: expected_reply}
 
     assert {:ok, expected_state} == EchoDispatcher.dispatch(:mllp_hl7, message, state)
+  end
+
+  test "Echo dispatcher accepts HL7, logs, and returns application_reject" do
+    state = %MLLP.FramingContext{}
+    message = "eh?"
+
+    MLLP.Ack.get_ack_for_message(
+      HL7.Message.new("eh?"),
+      :application_reject,
+      "A real MLLP message dispatcher was not provided"
+    )
+    |> to_string()
+    |> MLLP.Envelope.wrap_message()
+
+    # expected_state = %{state | reply_buffer: expected_reply}
+
+    assert {:ok, state1} = EchoDispatcher.dispatch(:mllp_unknown, message, state)
+    assert state1.reply_buffer =~ "|P|2.5\rMSA|AR|"
   end
 end

--- a/test/echo_dispatcher_test.exs
+++ b/test/echo_dispatcher_test.exs
@@ -36,6 +36,6 @@ defmodule EchoDispatcherTest do
     # expected_state = %{state | reply_buffer: expected_reply}
 
     assert {:ok, state1} = EchoDispatcher.dispatch(:mllp_unknown, message, state)
-    assert state1.reply_buffer =~ "|P|2.5\rMSA|AR|"
+    assert state1.reply_buffer =~ "mllp_unknown"
   end
 end

--- a/test/receiver_test.exs
+++ b/test/receiver_test.exs
@@ -107,7 +107,7 @@ defmodule ReceiverTest do
       end)
 
       capture_log(fn ->
-        assert tcp_connect_send_receive_and_close(port, msg) =~ "MSA|AR|01052901"
+        assert tcp_connect_send_receive_and_close(port, msg) =~ "MSA|AA|01052901"
       end)
     end
 

--- a/test/receiver_test.exs
+++ b/test/receiver_test.exs
@@ -103,7 +103,7 @@ defmodule ReceiverTest do
       |> expect(:dispatch, fn :mllp_hl7,
                               _,
                               %FramingContext{receiver_context: %{foo: :bar}} = state ->
-        {:ok, %{state | reply_buffer: "MSA|AR|01052901"}}
+        {:ok, %{state | reply_buffer: "MSA|AA|01052901"}}
       end)
 
       capture_log(fn ->


### PR DESCRIPTION
This modifies the echo dispatcher to respond with an ack or nack depending on the message being deemed  as  valid or vs  always returning a nack. 

It also modifies the function head to accept any type where before it would crash if it was given `:mllp_unknown` as the  type. 