### PR TITLE
Add backoff to client connection handling

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule MLLP.MixProject do
       {:telemetry, "~> 0.4.3"},
       {:ranch, "~> 1.8.0"},
       {:elixir_hl7, "~> 0.6.0"},
+      {:backoff, "~> 1.1.6"},
       {:ex_doc, "~> 0.24.2", only: :dev, runtime: false},
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:mix_test_watch, "~> 1.0.2", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "backoff": {:hex, :backoff, "1.1.6", "83b72ed2108ba1ee8f7d1c22e0b4a00cfe3593a67dbc792799e8cce9f42f796b", [:rebar3], [], "hexpm", "cf0cfff8995fb20562f822e5cc47d8ccf664c5ecdc26a684cbe85c225f9d7c39"},
   "certifi": {:hex, :certifi, "2.6.1", "dbab8e5e155a0763eea978c913ca280a6b544bfa115633fa20249c3d396d9493", [:rebar3], [], "hexpm", "524c97b4991b3849dd5c17a631223896272c6b0af446778ba4675a1dff53bb7e"},
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.17", "6f3c7e94170377ba45241d394389e800fb15adc5de51d0a3cd52ae766aafd63f", [:mix], [], "hexpm", "f93ac89c9feca61c165b264b5837bf82344d13bebc634cd575cb711e2e342023"},

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -73,6 +73,45 @@ defmodule ClientTest do
     end
   end
 
+  describe "uses backoff to handle connection" do
+    test "with base state" do
+      address = {127, 0, 0, 1}
+      port = 4090
+      socket = make_ref()
+
+      expect(MLLP.TCPMock, :connect, fn ^address,
+                                        ^port,
+                                        [:binary, {:packet, 0}, {:active, false}],
+                                        2000 ->
+        {:ok, socket}
+      end)
+
+      {:ok, pid} = Client.start_link(address, port, tcp: MLLP.TCPMock, use_backoff: true)
+
+      state = :sys.get_state(pid)
+
+      assert {:backoff, 1, 180, 1, :normal, _, _} = state.backoff
+    end
+
+    test "after connection failure" do
+      address = {127, 0, 0, 1}
+      port = 4090
+
+      expect(MLLP.TCPMock, :connect, fn ^address,
+                                        ^port,
+                                        [:binary, {:packet, 0}, {:active, false}],
+                                        2000 ->
+        {:error, "error"}
+      end)
+
+      {:ok, pid} = Client.start_link(address, port, tcp: MLLP.TCPMock, use_backoff: true)
+
+      state = :sys.get_state(pid)
+
+      assert {:backoff, 1, 180, 2, :normal, _, _} = state.backoff
+    end
+  end
+
   describe "handle_info/2" do
     test "handles unexpected info messages" do
       assert {:ok, pid} = MLLP.Client.start_link({127, 0, 0, 1}, 9998, use_backoff: true)

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -75,7 +75,7 @@ defmodule ClientTest do
 
   describe "handle_info/2" do
     test "handles unexpected info messages" do
-      assert {:ok, pid} = MLLP.Client.start_link({127, 0, 0, 1}, 9998)
+      assert {:ok, pid} = MLLP.Client.start_link({127, 0, 0, 1}, 9998, use_backoff: true)
 
       assert capture_log(fn ->
                Kernel.send(pid, :eh?)
@@ -107,7 +107,7 @@ defmodule ClientTest do
       |> expect(:send, fn ^socket, ^packet -> :ok end)
       |> expect(:recv, fn ^socket, 0, :infinity -> {:ok, tcp_reply} end)
 
-      {:ok, client} = Client.start_link(address, port, tcp: MLLP.TCPMock)
+      {:ok, client} = Client.start_link(address, port, tcp: MLLP.TCPMock, use_backoff: true)
 
       expected_ack = %MLLP.Ack{acknowledgement_code: "AA", text_message: "You win!"}
 


### PR DESCRIPTION
Addresses issue #18  

Adds an exponential backoff to handle reconnection of client. This is an option available that defaults to false.