### PR TITLE
Updated logging levels for MLLP.Client.terminate/2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.4
-erlang 24.1.7
+elixir 1.14.2
+erlang 25.2

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -450,6 +450,11 @@ defmodule MLLP.Client do
   end
 
   @doc false
+  def terminate(reason = :normal, state) do
+    Logger.debug("Client socket terminated. Reason: #{inspect(reason)} State #{inspect(state)}")
+    stop_connection(state, reason, "process terminated")
+  end
+
   def terminate(reason, state) do
     Logger.error("Client socket terminated. Reason: #{inspect(reason)} State #{inspect(state)}")
     stop_connection(state, reason, "process terminated")

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -277,6 +277,28 @@ defmodule ClientTest do
     end
   end
 
+  describe "terminate/2" do
+    test "logs debug message when reason is :normal" do
+      Logger.configure(level: :debug)
+      {:ok, pid} = Client.start_link({127,0,0,1}, 9999)
+      state = :sys.get_state(pid)
+
+      assert capture_log([level: :debug], fn ->
+        Client.terminate(:normal, state)
+      end) =~ "Client socket terminated. Reason: :normal"
+    end
+
+    test "logs error for any other reason" do
+      Logger.configure(level: :debug)
+      {:ok, pid} = Client.start_link({127,0,0,1}, 9999)
+      state = :sys.get_state(pid)
+
+      assert capture_log([level: :error], fn ->
+        Client.terminate(:shutdown, state)
+      end) =~ "Client socket terminated. Reason: :shutdown"
+    end
+  end
+
   defp telemetry_event(
          [:mllp, :client, event_name] = _full_event_name,
          measurements,


### PR DESCRIPTION
Fixes issue #59 

Client.terminate/2 now logs at the :error level when Client is stopped with any reason other than :normal. If Client is stopped for reason :normal, it only logs at the :debug level. 
