### PR TITLE
Allow MLLP connections to be proactively monitored with `is_closed?/1`

### DIFF
--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -368,17 +368,12 @@ defmodule MLLP.Client do
     {:reply, state.pending_reconnect != nil, state}
   end
 
+  def handle_call(:is_closed, _reply, %State{socket: nil} = state) do
+    {:reply, true, state}
+  end
+
   def handle_call(:is_closed, _reply, state) do
-    {:reply, (state.socket == nil ||
-      case state.tcp.recv(state.socket, 0, 1) do
-        {:error, :closed} ->
-          true
-        {:error, :enotconn} ->
-          true
-        _ ->
-          false
-      end
-    ) == true, state}
+    {:reply, state.tcp.is_closed?(state.socket), state}
   end
 
   def handle_call(:reconnect, _from, state) do

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -247,6 +247,18 @@ defmodule MLLP.Client do
   def is_connected?(pid), do: GenServer.call(pid, :is_connected)
 
   @doc """
+  Returns true if the connection is closed, otherwise false.
+  """
+  @spec is_closed?(pid :: pid()) :: boolean()
+  def is_closed?(pid), do: GenServer.call(pid, :is_closed)
+
+  @doc """
+  Returns true if the client is or will be attempting to reconnect, otherwise false.
+  """
+  @spec is_pending_reconnect?(pid :: pid()) :: boolean()
+  def is_pending_reconnect?(pid), do: GenServer.call(pid, :is_pending_reconnect)
+
+  @doc """
   Instructs the client to disconnect (if connected) and attempt a reconnect.
   """
   @spec reconnect(pid :: pid()) :: :ok
@@ -350,6 +362,23 @@ defmodule MLLP.Client do
 
   def handle_call(:is_connected, _reply, state) do
     {:reply, (state.socket && !state.pending_reconnect) == true, state}
+  end
+
+  def handle_call(:is_pending_reconnect, _reply, state) do
+    {:reply, state.pending_reconnect != nil, state}
+  end
+
+  def handle_call(:is_closed, _reply, state) do
+    {:reply, (state.socket == nil ||
+      case state.tcp.recv(state.socket, 0, 1) do
+        {:error, :closed} ->
+          true
+        {:error, :enotconn} ->
+          true
+        _ ->
+          false
+      end
+    ) == true, state}
   end
 
   def handle_call(:reconnect, _from, state) do

--- a/lib/mllp/tcp.ex
+++ b/lib/mllp/tcp.ex
@@ -25,6 +25,8 @@ defmodule MLLP.TCP do
   defdelegate connect(address, port, options, timeout), to: :gen_tcp
   defdelegate close(socket), to: :gen_tcp
 
+  require Logger
+
   @doc """
   Checks if the socket is closed.
   It does so by attempting to read any data from the socket.
@@ -42,8 +44,11 @@ defmodule MLLP.TCP do
   @spec is_closed?(socket :: :gen_tcp.socket()) :: boolean()
   def is_closed?(socket) do
     case recv(socket, _length = 0, _timeout = 1) do
-      {:error, reason} -> if reason == :timeout, do: false, else: true
-      _ -> false
+      {:ok, _} -> false
+      {:error, :timeout} -> false
+      {:error, reason} ->
+        Logger.warn("Socket appears to be closed. Reason: #{reason}")
+        true
     end
   end
 end

--- a/lib/mllp/tcp.ex
+++ b/lib/mllp/tcp.ex
@@ -42,8 +42,7 @@ defmodule MLLP.TCP do
   @spec is_closed?(socket :: :gen_tcp.socket()) :: boolean()
   def is_closed?(socket) do
     case recv(socket, _length = 0, _timeout = 1) do
-      {:error, :closed} -> true
-      {:error, :enotconn} -> true
+      {:error, reason} -> if reason == :timeout, do: false, else: true
       _ -> false
     end
   end


### PR DESCRIPTION
We have a simple service built around this library that translates HTTP API calls into MLLP messages.

On the receiving end of these messages, our peer sometimes hangs up. We want to reconnect as quickly as possible (and notify ourselves whenever the connection disconnects) instead of waiting until we attempt to send another message.

To do so, we need to introspect the status of a client connection. This PR adds a function to `Client` to do so.

Requested points of feedback/review:
- Is checking the TCP connection status with `recv(socket, _length = 0, _timeout = 1)` appropriate? Does it create a possible race-condition whereby checking the status accidentally intercepts bytes from the socket that should be read elsewhere?
- Is it necessary to also add a similar `is_closed?` function to `MLLP.TLS`?

cc @mfos239
