### PR TITLE
use socket_opts when they're specified

### DIFF
--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -681,12 +681,15 @@ defmodule MLLP.Client do
 
     send_opts = Map.merge(@default_send_opts, send_opts)
 
+    socket_opts = Keyword.merge(@default_opts[:socket_opts], opts[:socket_opts] || [])
+
     opts
     |> Map.merge(@default_opts)
     |> Map.put_new(:tcp, socket_module)
     |> Map.put(:pid, self())
     |> Map.put(:tls_opts, opts.tls)
     |> Map.put(:send_opts, send_opts)
+    |> Map.put(:socket_opts, socket_opts)
     |> Map.put(:backoff, backoff)
   end
 


### PR DESCRIPTION
Prior to this change MLLP.Client was throwing away user-supplied `socket_opts` when merging in @default_opts