### PR TITLE
Backoff reset

### DIFF
--- a/test/client_and_receiver_integration_test.exs
+++ b/test/client_and_receiver_integration_test.exs
@@ -286,12 +286,14 @@ defmodule ClientAndReceiverIntegrationTest do
         )
 
       capture_log(fn ->
-        {:error, _} = MLLP.Client.send(client_pid, "MSH|NOREPLY", %{reply_timeout: 1})
+        {:error, %MLLP.Client.Error{reason: :timeout}} =
+          MLLP.Client.send(client_pid, "MSH|NOREPLY", %{reply_timeout: 1})
       end)
 
       # Wait for reconnect timer
       Process.sleep(10)
-      assert Process.alive?(client_pid)
+      assert MLLP.Client.is_connected?(client_pid)
+      {:ok, _} = MLLP.Client.send(client_pid, "MSH|REPLY")
 
       assert Enum.count(open_ports_for_pid(client_pid)) == 1
     end


### PR DESCRIPTION
- Reset the backoff timer on failing `send`, so the client waits less for the next `reconnect` attempt.
- Set `keepalive=true` as the default socket option.