### PR TITLE
Custom SSL transport option

### DIFF
--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -243,8 +243,13 @@ defmodule MLLP.Receiver do
 
         {tls_options, options1} ->
           verify_peer = Keyword.get(tls_options, :verify)
+          ssl_transport = Keyword.get(tls_options, :ssl_transport, :ranch_ssl)
 
-          {:ranch_ssl, Keyword.merge(get_peer_options(verify_peer), tls_options), options1}
+          {ssl_transport,
+           Keyword.merge(
+             get_peer_options(verify_peer),
+             tls_options |> Keyword.delete(:ssl_transport)
+           ), options1}
       end
 
     socket_opts = get_socket_options(transport_opts, port) ++ tls_options1
@@ -338,6 +343,7 @@ defmodule MLLP.Receiver do
 
   def handle_info({message, socket, data}, state) when message in [:tcp, :ssl] do
     Logger.debug(fn -> "Receiver received data: [#{inspect(data)}]." end)
+
     framing_context = handle_received_data(socket, data, state.framing_context, state.transport)
     {:noreply, %{state | framing_context: framing_context}}
   end

--- a/lib/mllp/tls_logging_transport.ex
+++ b/lib/mllp/tls_logging_transport.ex
@@ -1,0 +1,103 @@
+defmodule MLLP.TLS.HandshakeLoggingTransport do
+  @behaviour :ranch_transport
+
+  require Logger
+
+  @impl true
+  defdelegate name(), to: :ranch_ssl
+
+  @impl true
+  defdelegate secure(), to: :ranch_ssl
+
+  @impl true
+  defdelegate messages(), to: :ranch_ssl
+
+  @impl true
+  defdelegate listen(opts), to: :ranch_ssl
+
+  defdelegate disallowed_listen_options(), to: :ranch_ssl
+
+  @impl true
+  defdelegate accept(socket, timeout), to: :ranch_ssl
+  defdelegate accept_ack(socket, timeout), to: :ranch_ssl
+
+  @impl true
+  defdelegate connect(string, port_number, opts), to: :ranch_ssl
+
+  @impl true
+  defdelegate connect(string, port_number, opts, timeout), to: :ranch_ssl
+
+  @impl true
+  defdelegate recv(socket, length, timeout), to: :ranch_ssl
+
+  @impl true
+  defdelegate recv_proxy_header(socket, timeout), to: :ranch_ssl
+
+  @impl true
+  defdelegate send(socket, data), to: :ranch_ssl
+
+  @impl true
+  defdelegate sendfile(socket, file), to: :ranch_ssl
+
+  @impl true
+  defdelegate sendfile(socket, file, offset, bytes), to: :ranch_ssl
+
+  @impl true
+  defdelegate sendfile(socket, file, offset, bytes, opts), to: :ranch_ssl
+
+  @impl true
+  defdelegate setopts(socket, opts), to: :ranch_ssl
+
+  @impl true
+  defdelegate getopts(socket, opts), to: :ranch_ssl
+
+  @impl true
+  defdelegate getstat(socket), to: :ranch_ssl
+
+  @impl true
+  defdelegate getstat(socket, opt_names), to: :ranch_ssl
+
+  @impl true
+  defdelegate controlling_process(socket, pid), to: :ranch_ssl
+
+  @impl true
+  defdelegate peername(socket), to: :ranch_ssl
+
+  @impl true
+  defdelegate sockname(socket), to: :ranch_ssl
+
+  @impl true
+  defdelegate shutdown(socket, how), to: :ranch_ssl
+
+  @impl true
+  defdelegate close(socket), to: :ranch_ssl
+
+  @impl true
+  def handshake(socket, opts, timeout) do
+    peer_data =
+      case peername(socket) do
+        {:ok, {ip, port}} ->
+          {ip, port}
+
+        {:error, peername_error} ->
+          {nil, peername_error}
+      end
+
+    case :ssl.handshake(socket, opts, timeout) do
+      {:ok, new_socket} ->
+        {:ok, new_socket}
+
+      {:error, _} = handshake_error ->
+        log_peer(peer_data)
+        handshake_error
+    end
+  end
+
+  defp log_peer({nil, peername_error}) do
+    Logger.error("Handshake failure; peer is undetected (#{inspect(peername_error)})")
+  end
+
+  defp log_peer({ip, port}) do
+    Logger.error("Handshake failure on connection attempt from #{inspect(ip)}:#{inspect(port)}")
+  end
+end


### PR DESCRIPTION
This change allows to use a custom implementation of SSL transport. The default option is `:ranch_ssl`. 
The implementation module must implement the `ranch_transport` behavior. 
[The example of implementation](https://github.com/bokner/elixir-mllp/blob/ssl_transport_opt/lib/mllp/tls_logging_transport.ex) (which logs peer info for unsuccessful TLS handshakes) is included. 