### PR TITLE
Prefix the library logs

### DIFF
--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -629,7 +629,7 @@ defmodule MLLP.Client do
         reply_to_caller({:ok, IO.iodata_to_binary(new_buf)}, data)
 
       false ->
-        log(:debug, "Client #{inspect(self())} received a MLLP fragment: #{reply}")
+        log(:debug, "Client #{inspect(self())} received a MLLP fragment: #{inspect(reply)}")
 
         data
         |> Map.put(:receive_buffer, new_buf)

--- a/lib/mllp/default_packet_framer.ex
+++ b/lib/mllp/default_packet_framer.ex
@@ -1,5 +1,3 @@
 defmodule MLLP.DefaultPacketFramer do
-  require Logger
-
   use MLLP.PacketFramer
 end

--- a/lib/mllp/echo_dispatcher.ex
+++ b/lib/mllp/echo_dispatcher.ex
@@ -2,12 +2,12 @@ defmodule MLLP.EchoDispatcher do
   @moduledoc """
   Echo dispatcher informs the user that a dispatch function was not set and returns an application_accept
   or application_reject depending on if the message is valid (String) or not. Useful for debugging and serves
-  as an example for writing your own dispatcher. 
+  as an example for writing your own dispatcher.
   """
 
-  require Logger
-
   @behaviour MLLP.Dispatcher
+
+  import MLLP.Utils
 
   @spec dispatch(:mllp_hl7 | :mllp_unknown, binary(), MLLP.FramingContext.t()) ::
           {:ok, MLLP.FramingContext.t()}
@@ -17,7 +17,8 @@ defmodule MLLP.EchoDispatcher do
   end
 
   def dispatch(:mllp_hl7, message, state) when is_binary(message) do
-    Logger.info(
+    log(
+      :info,
       "The EchoDispatcher simply logs and discards messages. Message type: :mllp_hl7 Message: #{message}"
     )
 

--- a/lib/mllp/envelope.ex
+++ b/lib/mllp/envelope.ex
@@ -16,7 +16,8 @@ defmodule MLLP.Envelope do
       <EB><CR>
 
   """
-  require Logger
+
+  import MLLP.Utils
 
   # ^K - VT (Vertical Tab)
   @sb <<0x0B>>
@@ -87,7 +88,7 @@ defmodule MLLP.Envelope do
   @spec wrap_message(binary()) :: binary() | no_return
   def wrap_message(<<11, _::binary>> = message) do
     if String.ends_with?(message, @ending) do
-      Logger.debug("MLLP Envelope performed unnecessary wrapping of wrapped message")
+      log(:debug, "MLLP Envelope performed unnecessary wrapping of wrapped message")
       message
     else
       raise(ArgumentError, message: "MLLP Envelope cannot wrap a partially wrapped message")
@@ -119,7 +120,7 @@ defmodule MLLP.Envelope do
     if String.ends_with?(message, @ending) do
       raise(ArgumentError, message: "cannot unwrap a partially wrapped message")
     else
-      Logger.debug("MLLP Envelope performed unnecessary unwrapping of unwrapped message")
+      log(:debug, "MLLP Envelope performed unnecessary unwrapping of unwrapped message")
       message
     end
   end

--- a/lib/mllp/packet_framer.ex
+++ b/lib/mllp/packet_framer.ex
@@ -4,6 +4,7 @@ defmodule MLLP.PacketFramer do
 
   defmacro __using__(opts) do
     alias MLLP.FramingContext
+    import MLLP.Utils
 
     {opt_frame_types, _} =
       opts
@@ -26,8 +27,6 @@ defmodule MLLP.PacketFramer do
 
     quote do
       @behaviour MLLP.PacketFramer
-
-      require Logger
 
       @doc false
       @spec handle_packet(packet :: String.t(), state :: MLLP.FramingContext.t()) ::
@@ -174,7 +173,7 @@ defmodule MLLP.PacketFramer do
       end
 
       def handle_unframed(unframed) do
-        Logger.error("The DefaultPacketFramer is discarding unexpected data: #{unframed}")
+        log(:error, "The DefaultPacketFramer is discarding unexpected data: #{unframed}")
       end
 
       defoverridable handle_unframed: 1

--- a/lib/mllp/peer.ex
+++ b/lib/mllp/peer.ex
@@ -1,6 +1,4 @@
 defmodule MLLP.Peer do
-  require Logger
-
   @type t :: %{
           :transport => :ranch_tcp | :ranch_ssl,
           :socket => :ranch_transport.socket(),

--- a/lib/mllp/tls_logging_transport.ex
+++ b/lib/mllp/tls_logging_transport.ex
@@ -1,7 +1,7 @@
 defmodule MLLP.TLS.HandshakeLoggingTransport do
   @behaviour :ranch_transport
 
-  require Logger
+  import MLLP.Utils
 
   @impl true
   defdelegate name(), to: :ranch_ssl
@@ -94,10 +94,10 @@ defmodule MLLP.TLS.HandshakeLoggingTransport do
   end
 
   defp log_peer({nil, peername_error}) do
-    Logger.error("Handshake failure; peer is undetected (#{inspect(peername_error)})")
+    log(:error, "Handshake failure; peer is undetected (#{inspect(peername_error)})")
   end
 
   defp log_peer({ip, port}) do
-    Logger.error("Handshake failure on connection attempt from #{inspect(ip)}:#{inspect(port)}")
+    log(:error, "Handshake failure on connection attempt from #{inspect(ip)}:#{inspect(port)}")
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,15 +1,15 @@
 defmodule MLLP.Utils do
   require Logger
-  @log_prefix "ELIXIR-MLLP :: "
-  def log(level, message) do
-    Logger.log(level, format_message(message))
+
+  def log(level, message, prefix \\ nil) do
+    Logger.log(level, format_message(message, prefix))
   end
 
-  defp format_message(message) when is_binary(message) do
-    @log_prefix <> message
-  end
-
-  defp format_message(message) do
-    @log_prefix <> inspect(message)
+  defp format_message(message, prefix) do
+    if prefix do
+      "#{inspect(prefix)} :: " <> message
+    else
+      message
+    end
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,0 +1,15 @@
+defmodule MLLP.Utils do
+  require Logger
+  @log_prefix "ELIXIR-MLLP :: "
+  def log(level, message) do
+    Logger.log(level, format_message(message))
+  end
+
+  defp format_message(message) when is_binary(message) do
+    @log_prefix <> message
+  end
+
+  defp format_message(message) do
+    @log_prefix <> inspect(message)
+  end
+end


### PR DESCRIPTION
This change will prefix the logs emitted by this library. The intent is to make it easier to identify them in the log output. Currently, the prefix is hardcoded in `utils.ex`.

Also, there may be a better way of doing things. I had to use two clauses for `MLLP.Utils.format_message/1`, as `ExUnit.CaptureLog.capture_log/2` sometimes truncates the output, which could result in failing tests. More specifically, if you comment out the first clause of `MLLP.Utils.format_message/1`, one of the tests in 'client_test.exs` will fail.

Edit: @starbelly found the issue, and that was a missing 'inspect' in the client's logs. 
