### PR TITLE
Add reference to options type

### DIFF
--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -41,7 +41,8 @@ defmodule MLLP.Receiver do
           dispatcher: module(),
           packet_framer: module(),
           transport_opts: :ranch.opts(),
-          context: map()
+          context: map(),
+          ref: reference()
         ]
 
   @behaviour :ranch_protocol

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -42,7 +42,7 @@ defmodule MLLP.Receiver do
           packet_framer: module(),
           transport_opts: :ranch.opts(),
           context: map(),
-          ref: reference()
+          ref: term()
         ]
 
   @behaviour :ranch_protocol


### PR DESCRIPTION
This makes the options() type match what's allowed to pass in through [child_spec/1](https://eng.d2iq.com/blog/a-long-journey-to-cross-platform-developer-tooling-utopia-for-now/) as well.

Fixes https://github.com/HCA-Healthcare/elixir-mllp/issues/75