### PR TITLE
Miscellaneous refactoring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   MIX_ENV: test
   otp-version: '24'
   elixir-version: '1.14'
-  cache-version: '3'
+  cache-version: '4'
 
 jobs:
   build:

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
 import Config
 
-config :logger, level: :warn
+config :logger, level: :warning

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -201,12 +201,15 @@ defmodule MLLP.Client do
   end
 
   def format_error(posix) when is_atom(posix) do
-    case :inet.format_error(posix) do
-      ~c"unknown POSIX error" ->
-        inspect(posix)
+    posix_error_str =
+      posix
+      |> :inet.format_error()
+      |> to_string()
 
-      char_list ->
-        to_string(char_list)
+    if String.starts_with?(posix_error_str, "unknown POSIX error") do
+      inspect(posix)
+    else
+      posix_error_str
     end
   end
 
@@ -539,7 +542,8 @@ defmodule MLLP.Client do
   end
 
   def receiving({:call, from}, {:send, _message, _options}, _data) do
-    {:keep_state_and_data, [{:reply, from, format_reply({:error, :busy_with_other_call}, :sending)}]}
+    {:keep_state_and_data,
+     [{:reply, from, format_reply({:error, :busy_with_other_call}, :sending)}]}
   end
 
   def receiving(:state_timeout, :receive_timeout, data) do

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -200,14 +200,16 @@ defmodule MLLP.Client do
     "Unexpected packet received"
   end
 
-  def format_error(posix) when is_atom(posix) do
+  def format_error(err) when is_atom(err) do
+    # Check if that's a POSIX error
     posix_error_str =
-      posix
+      err
       |> :inet.format_error()
       |> to_string()
 
     if String.starts_with?(posix_error_str, "unknown POSIX error") do
-      inspect(posix)
+      # No, it's not...
+      inspect(err)
     else
       posix_error_str
     end

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -586,7 +586,7 @@ defmodule MLLP.Client do
   ########################################
 
   defp unexpected_message(state, event, message) do
-    Logger.warn(
+    Logger.warning(
       "Event: #{inspect(event)} in state #{state}. Unknown message received => #{inspect(message)}"
     )
 

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -481,7 +481,7 @@ defmodule MLLP.Client do
           data
         )
 
-        error_reply = {:error, new_error(:send, reason)}
+        error_reply = {:error, new_error(:sending, reason)}
         {:keep_state_and_data, [{:reply, from, error_reply}]}
     end
   end

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -202,7 +202,7 @@ defmodule MLLP.Client do
 
   def format_error(posix) when is_atom(posix) do
     case :inet.format_error(posix) do
-      'unknown POSIX error' ->
+      ~c"unknown POSIX error" ->
         inspect(posix)
 
       char_list ->
@@ -842,8 +842,7 @@ defmodule MLLP.Client do
 
     socket_opts = Keyword.merge(default_socket_opts(), opts[:socket_opts] || [])
 
-    opts
-    |> Map.merge(default_opts())
+    Map.merge(default_opts(), opts)
     |> Map.put_new(:tcp, socket_module)
     |> Map.put(:pid, self())
     |> Map.put(:tls_opts, opts.tls)

--- a/lib/mllp/receiver.ex
+++ b/lib/mllp/receiver.ex
@@ -235,7 +235,7 @@ defmodule MLLP.Receiver do
     {transport_module, tls_options1, transport_opts1} =
       case Map.pop(transport_opts, :tls) do
         {nil, options1} ->
-          Logger.warn(
+          Logger.warning(
             "Starting listener on a non secured socket, data will be passed over unencrypted connection!"
           )
 
@@ -334,7 +334,9 @@ defmodule MLLP.Receiver do
         :gen_server.enter_loop(__MODULE__, [], state)
 
       {:error, error} ->
-        Logger.warn("Failed to verify client #{inspect(client_info)}, error: #{inspect(error)}")
+        Logger.warning(
+          "Failed to verify client #{inspect(client_info)}, error: #{inspect(error)}"
+        )
 
         {:stop,
          %{message: "Failed to verify client #{inspect(client_info)}, error: #{inspect(error)}"}}
@@ -364,7 +366,7 @@ defmodule MLLP.Receiver do
   end
 
   def handle_info(msg, state) do
-    Logger.warn("Unexpected handle_info for msg [#{inspect(msg)}].")
+    Logger.warning("Unexpected handle_info for msg [#{inspect(msg)}].")
     {:noreply, state}
   end
 
@@ -433,7 +435,7 @@ defmodule MLLP.Receiver do
         address
 
       error ->
-        Logger.warn(
+        Logger.warning(
           "IP/hostname #{inspect(name)} provided is not a valid IP/hostname #{inspect(error)}. It will be filtered from allowed_clients list"
         )
 

--- a/lib/mllp/tls_logging_transport.ex
+++ b/lib/mllp/tls_logging_transport.ex
@@ -88,16 +88,20 @@ defmodule MLLP.TLS.HandshakeLoggingTransport do
         {:ok, new_socket}
 
       {:error, _} = handshake_error ->
-        log_peer(peer_data)
+        log_peer(peer_data, handshake_error)
         handshake_error
     end
   end
 
-  defp log_peer({nil, peername_error}) do
-    Logger.error("Handshake failure; peer is undetected (#{inspect(peername_error)})")
+  defp log_peer({nil, peername_error}, handshake_error) do
+    Logger.error(
+      "Handshake failure #{inspect(handshake_error)}; peer is undetected (#{inspect(peername_error)})"
+    )
   end
 
-  defp log_peer({ip, port}) do
-    Logger.error("Handshake failure on connection attempt from #{inspect(ip)}:#{inspect(port)}")
+  defp log_peer({ip, port}, handshake_error) do
+    Logger.error(
+      "Handshake failure #{inspect(handshake_error)} on connection attempt from #{inspect(ip)}:#{inspect(port)}"
+    )
   end
 end

--- a/test/client_and_receiver_integration_test.exs
+++ b/test/client_and_receiver_integration_test.exs
@@ -2,6 +2,7 @@ defmodule ClientAndReceiverIntegrationTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureLog
   import Mox
+  import MLLP.TestHelper.Utils
   setup :verify_on_exit!
   setup :set_mox_global
 
@@ -417,7 +418,7 @@ defmodule ClientAndReceiverIntegrationTest do
 
                Process.sleep(10)
                refute MLLP.Client.is_connected?(client_pid)
-             end) =~ "Handshake failure on connection attempt from {127, 0, 0, 1}"
+             end) =~ "hostname_check_failed"
     end
   end
 
@@ -506,7 +507,7 @@ defmodule ClientAndReceiverIntegrationTest do
         keyfile: keyfile
       ]
 
-      tls_alert = ctx[:reason] || []
+      tls_alert = ctx[:reason] || [{:options, {:certfile, ""}}]
 
       expected_error_reasons = [:einval, :no_socket, :closed] ++ tls_alert
 
@@ -523,15 +524,27 @@ defmodule ClientAndReceiverIntegrationTest do
     @tag verify: :verify_none
     @tag client_cert: ""
     @tag keyfile: ""
+    @tag reason: [{:options, {:certfile, ""}}]
     test "does not verify client cert if verify none option is provided on receiver", ctx do
-      make_call_and_assert_success(ctx, ctx.ack)
+      if otp_release() < 26 do
+        make_call_and_assert_success(ctx, ctx.ack)
+      else
+        make_call_and_assert_failure(ctx, ctx.reason)
+      end
     end
 
     @tag port: 8162
     @tag client_cert: ""
     @tag keyfile: ""
 
-    @tag reason: [:handshake_failure, :certificate_required]
+    # @tag reason: if otp_release() < 26 do
+    #   [:handshake_failure, :certificate_required]
+    #   else
+    #    {:options, {:certfile, ""}}
+    # end
+
+    @tag reason: [:handshake_failure, :certificate_required, {:options, {:certfile, ""}}]
+
     test "no peer cert", ctx do
       make_call_and_assert_failure(ctx, ctx.expected_error_reasons)
     end
@@ -654,7 +667,7 @@ defmodule ClientAndReceiverIntegrationTest do
   defp open_ports_for_pid(pid) do
     Enum.filter(Port.list(), fn p ->
       info = Port.info(p)
-      Keyword.get(info, :name) == 'tcp_inet' and Keyword.get(info, :connected) == pid
+      Keyword.get(info, :name) == ~c"tcp_inet" and Keyword.get(info, :connected) == pid
     end)
   end
 

--- a/test/client_and_receiver_integration_test.exs
+++ b/test/client_and_receiver_integration_test.exs
@@ -537,12 +537,6 @@ defmodule ClientAndReceiverIntegrationTest do
     @tag client_cert: ""
     @tag keyfile: ""
 
-    # @tag reason: if otp_release() < 26 do
-    #   [:handshake_failure, :certificate_required]
-    #   else
-    #    {:options, {:certfile, ""}}
-    # end
-
     @tag reason: [:handshake_failure, :certificate_required, {:options, {:certfile, ""}}]
 
     test "no peer cert", ctx do

--- a/test/client_and_receiver_integration_test.exs
+++ b/test/client_and_receiver_integration_test.exs
@@ -127,7 +127,7 @@ defmodule ClientAndReceiverIntegrationTest do
 
       {:ok, client_pid} = MLLP.Client.start_link({127, 0, 0, 1}, port)
 
-      exp_err = %Error{context: :send, reason: :econnrefused, message: "connection refused"}
+      exp_err = %Error{context: :sending, reason: :econnrefused, message: "connection refused"}
       assert {:error, ^exp_err} = MLLP.Client.send(client_pid, "Eh?")
     end
 
@@ -201,7 +201,7 @@ defmodule ClientAndReceiverIntegrationTest do
 
       payload = "A simple message"
 
-      exp_err = %Error{context: :send, reason: :econnrefused, message: "connection refused"}
+      exp_err = %Error{context: :sending, reason: :econnrefused, message: "connection refused"}
       assert {:error, ^exp_err} = MLLP.Client.send(client_pid, payload)
 
       capture_log(fn -> MLLP.Client.stop(client_pid) end)
@@ -224,7 +224,7 @@ defmodule ClientAndReceiverIntegrationTest do
       {:error, %Error{context: context, message: message}} =
         MLLP.Client.send(client_pid, "Simple message")
 
-      assert context in [:send, :recv]
+      assert context in [:sending, :receiving]
       assert message in [MLLP.Client.format_error(:closed), MLLP.Client.format_error(:einval)]
 
       refute MLLP.Client.is_connected?(client_pid)
@@ -358,7 +358,7 @@ defmodule ClientAndReceiverIntegrationTest do
       {:ok, client_pid} =
         MLLP.Client.start_link({127, 0, 0, 1}, ctx.port, tls: ctx.client_tls_options)
 
-      assert {:error, %Error{reason: {:tls_alert, {:handshake_failure, _}}, context: :send}} =
+      assert {:error, %Error{reason: {:tls_alert, {:handshake_failure, _}}, context: :sending}} =
                MLLP.Client.send(
                  client_pid,
                  HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
@@ -445,7 +445,7 @@ defmodule ClientAndReceiverIntegrationTest do
           HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
         )
 
-      assert error.context in [:send, :recv]
+      assert error.context in [:sending, :receiving]
       assert error.reason in [:closed, :einval]
     end
 

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -27,8 +27,8 @@ defmodule ClientTest do
 
       assert match?({:ok, _}, MLLP.Client.start_link(:localhost, 9999))
       assert match?({:ok, _}, MLLP.Client.start_link("servera.app.net", 9999))
-      assert match?({:ok, _}, MLLP.Client.start_link('servera.unix.city.net', 9999))
-      assert match?({:ok, _}, MLLP.Client.start_link('127.0.0.1', 9999))
+      assert match?({:ok, _}, MLLP.Client.start_link(~c"servera.unix.city.net", 9999))
+      assert match?({:ok, _}, MLLP.Client.start_link(~c"127.0.0.1", 9999))
     end
 
     test "raises on invalid addresses" do
@@ -58,7 +58,7 @@ defmodule ClientTest do
       err =
         {:tls_alert,
          {:handshake_failure,
-          'TLS client: In state wait_cert_cr at ssl_handshake.erl:2017 generated CLIENT ALERT: Fatal - Handshake Failure\n {bad_cert,hostname_check_failed}'}}
+          ~c"TLS client: In state wait_cert_cr at ssl_handshake.erl:2017 generated CLIENT ALERT: Fatal - Handshake Failure\n {bad_cert,hostname_check_failed}"}}
 
       exp =
         "TLS client: In state wait_cert_cr at ssl_handshake.erl:2017 generated CLIENT ALERT: Fatal - Handshake Failure\n {bad_cert,hostname_check_failed}"
@@ -371,7 +371,7 @@ defmodule ClientTest do
 
       {:ok, client} = Client.start_link(address, port, tcp: MLLP.TCPMock)
 
-      assert {:error, %Error{message: "connection closed", context: :send, reason: :closed}} ==
+      assert {:error, %Error{message: "connection closed", context: :sending, reason: :closed}} ==
                Client.send(client, message)
     end
 
@@ -493,7 +493,7 @@ defmodule ClientTest do
 
       {:ok, client} = Client.start_link(address, port, tcp: MLLP.TCPMock)
 
-      assert {:error, %Error{message: "connection closed", context: :send, reason: :closed}} ==
+      assert {:error, %Error{message: "connection closed", context: :sending, reason: :closed}} ==
                Client.send_async(client, message)
     end
   end

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -263,7 +263,11 @@ defmodule ClientTest do
       message =
         "MSH|^~\\&|SuperOE|XYZImgCtr|MegaReg|XYZHospC|20060529090131-0500||ACK^O01|NOTRAILER|P|2.5\rMSA|AA|NOTRAILER\r"
 
-      expected_err = %MLLP.Client.Error{context: :recv, reason: :timeout, message: "timed out"}
+      expected_err = %MLLP.Client.Error{
+        context: :receiving,
+        reason: :timeout,
+        message: "timed out"
+      }
 
       log =
         capture_log([level: :debug], fn ->
@@ -313,7 +317,7 @@ defmodule ClientTest do
         "MSH|^~\\&|SuperOE|XYZImgCtr|MegaReg|XYZHospC|20060529090131-0500||ACK^O01|DONOTWRAP|P|2.5\rMSA|AA|DONOTWRAP\r"
 
       expected_err = %MLLP.Client.Error{
-        context: :recv,
+        context: :receiving,
         message: "Invalid header received in server acknowledgment",
         reason: :invalid_reply
       }
@@ -328,7 +332,7 @@ defmodule ClientTest do
       message = "This message has a TRAILER_WITHIN - beware!"
 
       expected_err = %MLLP.Client.Error{
-        context: :recv,
+        context: :receiving,
         message: "Data received after trailer",
         reason: :data_after_trailer
       }

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -70,8 +70,11 @@ defmodule ClientTest do
       assert MLLP.Client.format_error("some unknown error") == "some unknown error"
     end
 
-    test "when given terms that are not atoms" do
+    test "when given atoms (which are not POSIX errors)" do
       assert MLLP.Client.format_error(:eh?) == ":eh?"
+    end
+
+    test "when given terms" do
       assert MLLP.Client.format_error({:error, 42}) == "{:error, 42}"
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,3 +20,11 @@ end
 if should_generate_cert.(), do: System.cmd("sh", ["tls/tls.sh"])
 
 ExUnit.start()
+
+defmodule MLLP.TestHelper.Utils do
+  def otp_release() do
+    :erlang.system_info(:otp_release)
+    |> to_string()
+    |> String.to_integer()
+  end
+end


### PR DESCRIPTION
- Fix the bug with reading default options (which prevents, for instance, from using custom `telemetry` module)
- Unify `context` usage (it will represent what state FSM is at)
- Make unit tests compatible with OTP 26
- Replace deprecated `Logger.warn/1` with `Logger.warning/1`