### PR TITLE
Ignorning case when comparing peer cert common name with allowed clients

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,12 +30,12 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: restore-deps
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: restore-build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
@@ -58,12 +58,12 @@ jobs:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
       - name: restore-deps
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ env.otp-version }}-${ env.elixir-version }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: restore-build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-build-${{ env.otp-version }}-${{ env.elixir-version }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
@@ -87,17 +87,17 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: restore-deps
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: restore-build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: restore-plts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: priv/plts
           key: ${{ runner.os }}-mllp-dialyzer-${{ matrix.otp }}-${{ matrix.elixir }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}-${{ hashFiles(format('{0}{1}', github.workspace, '/priv/plts/mllp.plt')) }}
@@ -121,12 +121,12 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: restore-deps
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: restore-build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ env.cache-version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ mllp-*.tar
 /tls/server
 /tls/external
 /tls/expired_client
+/tls/client_mixed_case_cn
 

--- a/lib/mllp/peer.ex
+++ b/lib/mllp/peer.ex
@@ -52,9 +52,19 @@ defmodule MLLP.Peer do
     end
   end
 
-  defp match_fun({:cn, reference}, {_, reference}), do: true
-  defp match_fun(reference, {_, reference}), do: true
+  defp match_fun({:cn, reference_id}, {_, peer_cn}) do
+    match_cn?(reference_id, peer_cn)
+  end
+
+  defp match_fun(reference_id, {_, peer_cn}) do
+    match_cn?(reference_id, peer_cn)
+  end
+
   defp match_fun(_, _), do: false
+
+  defp match_cn?(reference_id, peer_cn) do
+    :string.equal(reference_id, peer_cn, true)
+  end
 
   defp fqdn_fun({:cn, value}), do: value
 

--- a/test/client_and_receiver_integration_test.exs
+++ b/test/client_and_receiver_integration_test.exs
@@ -665,6 +665,20 @@ defmodule ClientAndReceiverIntegrationTest do
       make_call_and_assert_success(ctx, ctx.ack)
     end
 
+    @tag port: 8170
+    @tag allowed_clients: ["CLIENT-1"]
+    test "accept peer cert with case mismatch", ctx do
+      make_call_and_assert_success(ctx, ctx.ack)
+    end
+
+    @tag port: 8171
+    @tag allowed_clients: ["mixed-CASE-client-cert"],
+         client_cert: "tls/client_mixed_case_cn/client_certificate.pem",
+         keyfile: "tls/client_mixed_case_cn/private_key.pem"
+    test "accept peer cert with mixed case CN", ctx do
+      make_call_and_assert_success(ctx, ctx.ack)
+    end
+
     defp make_call_and_assert_success(ctx, expected_result) do
       assert expected_result == start_client_and_send(ctx)
     end

--- a/tls/tls.sh
+++ b/tls/tls.sh
@@ -1,6 +1,6 @@
 cd tls
 
-mkdir root-ca client server expired_client
+mkdir root-ca client client_mixed_case_cn server expired_client
 cd root-ca
 rm index.txt
 touch index.txt
@@ -35,6 +35,17 @@ openssl req -new -key private_key.pem -out req.pem -outform PEM \
 cd ../root-ca
 openssl ca -config ../openssl.cnf -in ../client/req.pem -out \
     ../client/client_certificate.pem -notext -batch -extensions client_ca_extensions
+
+#Client Cert with mixed case CN
+cd ../client_mixed_case_cn
+
+openssl genrsa -out private_key.pem 2048
+openssl req -new -key private_key.pem -out req.pem -outform PEM \
+    -subj /CN=MIXED-CASE-client-cert/O=client/ -nodes
+
+cd ../root-ca
+openssl ca -config ../openssl.cnf -in ../client_mixed_case_cn/req.pem -out \
+    ../client_mixed_case_cn/client_certificate.pem -notext -batch -extensions client_ca_extensions
 
 #Client Expired Cert
 cd ../expired_client


### PR DESCRIPTION
resolve #88 
In some cases, we found certs are issued with mixed case CN and doing a case sensitive match caused issues. hostname verification worked fine but since :public_key.pkix_subject_id normalizes subject before returning it caused issues in applications which used connection info and used peer_name