### PR TITLE
Add response handler for MLLP.Client.send/xx

### DIFF
--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -651,7 +651,14 @@ defmodule MLLP.Client do
     receive_impl(reply, data)
   end
 
-  def receive_impl(reply, %{receive_buffer: buffer, last_byte_received: last_byte, response_handler: response_handler} = data) do
+  def receive_impl(
+        reply,
+        %{
+          receive_buffer: buffer,
+          last_byte_received: last_byte,
+          response_handler: response_handler
+        } = data
+      ) do
     new_buf = update_receive_buffer(buffer, reply)
 
     case trailer_check(reply, last_byte) do
@@ -664,13 +671,15 @@ defmodule MLLP.Client do
       true ->
         Logger.debug("Client #{inspect(self())} received a full MLLP!")
         full_mllp = IO.iodata_to_binary(new_buf)
+
         reply_to_caller({:ok, full_mllp}, data)
         |> tap(fn _ -> telemetry(:receive_valid, %{}, data) end)
-        |> tap(fn _ when is_function(response_handler, 1) ->
-            response_handler.(
-              MLLP.Envelope.unwrap_message(full_mllp)
-            )
-            _ -> :ok
+        |> tap(fn
+          _ when is_function(response_handler, 1) ->
+            response_handler.(MLLP.Envelope.unwrap_message(full_mllp))
+
+          _ ->
+            :ok
         end)
 
       false ->

--- a/lib/mllp/client.ex
+++ b/lib/mllp/client.ex
@@ -145,6 +145,7 @@ defmodule MLLP.Client do
           auto_reconnect_interval: non_neg_integer(),
           pid: pid() | nil,
           telemetry_module: module() | nil,
+          response_handler: function() | nil,
           tcp: module() | nil,
           tls_opts: Keyword.t(),
           socket_opts: Keyword.t(),
@@ -163,6 +164,7 @@ defmodule MLLP.Client do
             port: 0,
             pid: nil,
             telemetry_module: nil,
+            response_handler: nil,
             tcp: nil,
             tcp_error: nil,
             host_string: nil,
@@ -649,7 +651,7 @@ defmodule MLLP.Client do
     receive_impl(reply, data)
   end
 
-  def receive_impl(reply, %{receive_buffer: buffer, last_byte_received: last_byte} = data) do
+  def receive_impl(reply, %{receive_buffer: buffer, last_byte_received: last_byte, response_handler: response_handler} = data) do
     new_buf = update_receive_buffer(buffer, reply)
 
     case trailer_check(reply, last_byte) do
@@ -661,9 +663,15 @@ defmodule MLLP.Client do
 
       true ->
         Logger.debug("Client #{inspect(self())} received a full MLLP!")
-
-        reply_to_caller({:ok, IO.iodata_to_binary(new_buf)}, data)
+        full_mllp = IO.iodata_to_binary(new_buf)
+        reply_to_caller({:ok, full_mllp}, data)
         |> tap(fn _ -> telemetry(:receive_valid, %{}, data) end)
+        |> tap(fn _ when is_function(response_handler, 1) ->
+            response_handler.(
+              MLLP.Envelope.unwrap_message(full_mllp)
+            )
+            _ -> :ok
+        end)
 
       false ->
         Logger.debug("Client #{inspect(self())} received a MLLP fragment: #{reply}")

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -461,19 +461,21 @@ defmodule ClientTest do
 
       raw_hl7 = HL7.Examples.wikipedia_sample_hl7()
       message = HL7.Message.new(raw_hl7)
-      {:ok, pid} = MLLP.Client.start_link("127.0.0.1", 5555, response_handler: fn response ->
-        ## Captured response is a valid (raw) HL7 message
-        assert %HL7.Message{} = HL7.Message.new(response)
-        ## Prove that the response parser was called
-        Logger.debug("Response handler was called")
-      end)
+
+      {:ok, pid} =
+        MLLP.Client.start_link("127.0.0.1", 5555,
+          response_handler: fn response ->
+            ## Captured response is a valid (raw) HL7 message
+            assert %HL7.Message{} = HL7.Message.new(response)
+            ## Prove that the response parser was called
+            Logger.debug("Response handler was called")
+          end
+        )
 
       assert capture_log([level: :debug], fn ->
-          {:ok, :application_accept, _} = Client.send(pid, message)
-      end) =~ "Response handler was called"
-
+               {:ok, :application_accept, _} = Client.send(pid, message)
+             end) =~ "Response handler was called"
     end
-
   end
 
   describe "send_async/2" do

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -472,6 +472,8 @@ defmodule ClientTest do
           end
         )
 
+      :timer.sleep(1000)
+
       assert capture_log([level: :debug], fn ->
                {:ok, :application_accept, _} = Client.send(pid, message)
              end) =~ "Response handler was called"

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -463,7 +463,7 @@ defmodule ClientTest do
       message = HL7.Message.new(raw_hl7)
 
       {:ok, pid} =
-        MLLP.Client.start_link("127.0.0.1", 5555,
+        Client.start_link("127.0.0.1", 4090,
           response_handler: fn response ->
             ## Captured response is a valid (raw) HL7 message
             assert %HL7.Message{} = HL7.Message.new(response)

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -454,6 +454,26 @@ defmodule ClientTest do
       assert Enum.all?(1..2, fn _ -> Client.is_connected?(client) end)
       assert Task.await(send_task) == {:ok, slow_processing_msg}
     end
+
+    test "with response handler" do
+      require Logger
+      Logger.configure(level: :debug)
+
+      raw_hl7 = HL7.Examples.wikipedia_sample_hl7()
+      message = HL7.Message.new(raw_hl7)
+      {:ok, pid} = MLLP.Client.start_link("127.0.0.1", 5555, response_handler: fn response ->
+        ## Captured response is a valid (raw) HL7 message
+        assert %HL7.Message{} = HL7.Message.new(response)
+        ## Prove that the response parser was called
+        Logger.debug("Response handler was called")
+      end)
+
+      assert capture_log([level: :debug], fn ->
+          {:ok, :application_accept, _} = Client.send(pid, message)
+      end) =~ "Response handler was called"
+
+    end
+
   end
 
   describe "send_async/2" do

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -472,10 +472,9 @@ defmodule ClientTest do
           end
         )
 
-      :timer.sleep(1000)
-
       assert capture_log([level: :debug], fn ->
                {:ok, :application_accept, _} = Client.send(pid, message)
+               :timer.sleep(100)
              end) =~ "Response handler was called"
     end
   end


### PR DESCRIPTION
### The issue

The return of MLLP.Client.send/2,3,4 is insufficient for handling ACKs.

- In case the outgoing message is a raw HL7, the return does not contain ACK info:
```elixir
iex(34)> raw = HL7.Examples.wikipedia_sample_hl7
..................
iex(35)> Client.send(pid, raw)
{:ok,
 "MSH|^~\\&|SuperOE|XYZImgCtr|MegaReg|XYZHospC|20060529090131-0500||ACK^A01^ACK|01052901|P|2.5\rMSA|AA|01052901|A real MLLP message dispatcher was not provided\r"}
```

- In case the outgoing message is an `HL7.Message` struct, the return does not contain the ACK message.

```elixir
iex(38)> Client.send(pid, HL7.Message.new(raw))

{:ok, :application_accept,
 %MLLP.Ack{
   acknowledgement_code: "AA",
   text_message: "A real MLLP message dispatcher was not provided",
   hl7_ack_message: nil
 }} 
```

### The solution

I think that the best solution would be to unify the output of MLLP.Client.send/xx

This, however, would break an existing API.

The alternative (as per this PR) is to provide an option for the callback function that exposes a "wrapped" raw response.
This is implemented as a side effect (similar to the telemetry handler), so the API would be preserved. 
