### PR TITLE
Populate hl7_ack_message in the return of MLLP.Client.send/xx

### DIFF
--- a/lib/mllp/ack.ex
+++ b/lib/mllp/ack.ex
@@ -148,7 +148,11 @@ defmodule MLLP.Ack do
     ack_result = ack_msa |> HL7.Segment.get_part(1)
     text_message = ack_msa |> HL7.Segment.get_part(3)
 
-    ack = %__MODULE__{acknowledgement_code: ack_result, text_message: text_message}
+    ack = %__MODULE__{
+      acknowledgement_code: ack_result,
+      text_message: text_message,
+      hl7_ack_message: ack
+    }
 
     if String.contains?(ack_message_control_id, message_control_id) do
       case ack_result do

--- a/test/ack_test.exs
+++ b/test/ack_test.exs
@@ -100,7 +100,7 @@ defmodule AckTest do
       message = HL7.Examples.wikipedia_sample_hl7()
       ack_message = get_ack_for_wikipedia_example(:application_accept)
 
-      expected_ack = %Ack{acknowledgement_code: "AA"}
+      expected_ack = %Ack{acknowledgement_code: "AA", hl7_ack_message: ack_message}
 
       assert {:ok, :application_accept, expected_ack} ==
                Ack.verify_ack_against_message(message, ack_message)
@@ -109,7 +109,7 @@ defmodule AckTest do
     test "with code `AA`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example("AA")
-      expected_ack = %Ack{acknowledgement_code: "AA"}
+      expected_ack = %Ack{acknowledgement_code: "AA", hl7_ack_message: hl7_ack}
 
       assert {:ok, :application_accept, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)
@@ -118,7 +118,7 @@ defmodule AckTest do
     test "with code `CA`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example("CA")
-      expected_ack = %Ack{acknowledgement_code: "CA"}
+      expected_ack = %Ack{acknowledgement_code: "CA", hl7_ack_message: hl7_ack}
 
       assert {:ok, :application_accept, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)
@@ -127,7 +127,7 @@ defmodule AckTest do
     test "with code `application_reject`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example(:application_reject)
-      expected_ack = %Ack{acknowledgement_code: "AR"}
+      expected_ack = %Ack{acknowledgement_code: "AR", hl7_ack_message: hl7_ack}
 
       assert {:error, :application_reject, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)
@@ -136,7 +136,7 @@ defmodule AckTest do
     test "with code `AR`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example("AR")
-      expected_ack = %Ack{acknowledgement_code: "AR"}
+      expected_ack = %Ack{acknowledgement_code: "AR", hl7_ack_message: hl7_ack}
 
       assert {:error, :application_reject, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)
@@ -145,7 +145,7 @@ defmodule AckTest do
     test "with code `CR`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example("CR")
-      expected_ack = %Ack{acknowledgement_code: "CR"}
+      expected_ack = %Ack{acknowledgement_code: "CR", hl7_ack_message: hl7_ack}
 
       assert {:error, :application_reject, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)
@@ -154,7 +154,7 @@ defmodule AckTest do
     test "with code `application_error`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example(:application_error)
-      expected_ack = %Ack{acknowledgement_code: "AE"}
+      expected_ack = %Ack{acknowledgement_code: "AE", hl7_ack_message: hl7_ack}
 
       assert {:error, :application_error, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)
@@ -163,7 +163,7 @@ defmodule AckTest do
     test "with code `AE`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example("AE")
-      expected_ack = %Ack{acknowledgement_code: "AE"}
+      expected_ack = %Ack{acknowledgement_code: "AE", hl7_ack_message: hl7_ack}
 
       assert {:error, :application_error, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)
@@ -172,7 +172,7 @@ defmodule AckTest do
     test "with code `CE`" do
       hl7_message = HL7.Examples.wikipedia_sample_hl7()
       hl7_ack = get_ack_for_wikipedia_example("CE")
-      expected_ack = %Ack{acknowledgement_code: "CE"}
+      expected_ack = %Ack{acknowledgement_code: "CE", hl7_ack_message: hl7_ack}
 
       assert {:error, :application_error, expected_ack} ==
                Ack.verify_ack_against_message(hl7_message, hl7_ack)

--- a/test/client_and_receiver_integration_test.exs
+++ b/test/client_and_receiver_integration_test.exs
@@ -29,14 +29,10 @@ defmodule ClientAndReceiverIntegrationTest do
   end
 
   setup ctx do
-    ack = {
-      :ok,
-      :application_accept,
-      %MLLP.Ack{
-        acknowledgement_code: "AA",
-        hl7_ack_message: nil,
-        text_message: "A real MLLP message dispatcher was not provided"
-      }
+    ack = %MLLP.Ack{
+      acknowledgement_code: "AA",
+      hl7_ack_message: nil,
+      text_message: "A real MLLP message dispatcher was not provided"
     }
 
     transport_opts = ctx[:transport_opts] || %{}
@@ -290,7 +286,7 @@ defmodule ClientAndReceiverIntegrationTest do
       refute MLLP.Client.is_connected?(client_pid)
     end
 
-    test "with a larger message" do
+    test "with a larger message", ctx do
       port = 8152
 
       {:ok, %{pid: _receiver_pid}} =
@@ -306,17 +302,8 @@ defmodule ClientAndReceiverIntegrationTest do
            "ZNK|JUNK|" <> String.pad_leading("\r", 10000, "Z"))
         |> HL7.Message.new()
 
-      ack = MLLP.Client.send(client_pid, message)
-
-      expected =
-        {:ok, :application_accept,
-         %MLLP.Ack{
-           acknowledgement_code: "AA",
-           hl7_ack_message: nil,
-           text_message: ""
-         }}
-
-      assert expected == ack
+      {:ok, :application_accept, ack} = MLLP.Client.send(client_pid, message)
+      assert ctx.ack.acknowledgement_code == ack.acknowledgement_code
     end
   end
 
@@ -405,11 +392,13 @@ defmodule ClientAndReceiverIntegrationTest do
       {:ok, client_pid} =
         MLLP.Client.start_link("localhost", ctx.port, tls: ctx.client_tls_options)
 
-      assert ctx.ack ==
-               MLLP.Client.send(
-                 client_pid,
-                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
-               )
+      {:ok, :application_accept, ack} =
+        MLLP.Client.send(
+          client_pid,
+          HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+        )
+
+      assert ctx.ack.acknowledgement_code == ack.acknowledgement_code
     end
 
     @tag :tls
@@ -431,11 +420,13 @@ defmodule ClientAndReceiverIntegrationTest do
       {:ok, client_pid} =
         MLLP.Client.start_link("localhost", ctx.port, tls: [verify: :verify_none])
 
-      assert ctx.ack ==
-               MLLP.Client.send(
-                 client_pid,
-                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
-               )
+      {:ok, :application_accept, ack} =
+        MLLP.Client.send(
+          client_pid,
+          HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+        )
+
+      assert ctx.ack.acknowledgement_code == ack.acknowledgement_code
     end
 
     @tag :tls
@@ -485,11 +476,13 @@ defmodule ClientAndReceiverIntegrationTest do
       {:connected, %{socket: socket}} = :sys.get_state(client_pid)
       assert {:ok, _} = :ssl.getstat(socket)
 
-      assert ctx.ack ==
-               MLLP.Client.send(
-                 client_pid,
-                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
-               )
+      {:ok, :application_accept, ack} =
+        MLLP.Client.send(
+          client_pid,
+          HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+        )
+
+      assert ctx.ack.acknowledgement_code == ack.acknowledgement_code
     end
   end
 
@@ -568,11 +561,13 @@ defmodule ClientAndReceiverIntegrationTest do
     test "allow connection from allowed clients", ctx do
       {:ok, client_pid} = MLLP.Client.start_link("localhost", ctx.port)
 
-      assert ctx.ack ==
-               MLLP.Client.send(
-                 client_pid,
-                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
-               )
+      {:ok, :application_accept, ack} =
+        MLLP.Client.send(
+          client_pid,
+          HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+        )
+
+      assert ack.acknowledgement_code == ctx.ack.acknowledgement_code
     end
 
     @tag allowed_clients: [:localhost]
@@ -580,11 +575,13 @@ defmodule ClientAndReceiverIntegrationTest do
     test "atom is allowed as client ip or dns", ctx do
       {:ok, client_pid} = MLLP.Client.start_link("localhost", ctx.port)
 
-      assert ctx.ack ==
-               MLLP.Client.send(
-                 client_pid,
-                 HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
-               )
+      {:ok, :application_accept, ack} =
+        MLLP.Client.send(
+          client_pid,
+          HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
+        )
+
+      assert ctx.ack.acknowledgement_code == ack.acknowledgement_code
     end
   end
 
@@ -640,7 +637,7 @@ defmodule ClientAndReceiverIntegrationTest do
     @tag reason: [{:options, {:certfile, ""}}]
     test "does not verify client cert if verify none option is provided on receiver", ctx do
       if otp_release() < 26 do
-        make_call_and_assert_success(ctx, ctx.ack)
+        make_call_and_assert_success(ctx)
       else
         make_call_and_assert_failure(ctx, ctx.reason)
       end
@@ -658,13 +655,13 @@ defmodule ClientAndReceiverIntegrationTest do
 
     @tag port: 8163
     test "accepts a peer cert", ctx do
-      make_call_and_assert_success(ctx, ctx.ack)
+      make_call_and_assert_success(ctx)
     end
 
     @tag port: 8164
     @tag allowed_clients: ["client-1"]
     test "accepts peer cert for allowed client", ctx do
-      make_call_and_assert_success(ctx, ctx.ack)
+      make_call_and_assert_success(ctx)
     end
 
     @tag port: 8165
@@ -701,7 +698,7 @@ defmodule ClientAndReceiverIntegrationTest do
     @tag port: 8168
     @tag allowed_clients: ["client-x", "client-1"]
     test "accept peer cert from multiple allowed clients", ctx do
-      make_call_and_assert_success(ctx, ctx.ack)
+      make_call_and_assert_success(ctx)
     end
 
     @tag port: 8169, dispatcher: MLLP.DispatcherMock
@@ -721,13 +718,13 @@ defmodule ClientAndReceiverIntegrationTest do
         {:ok, %{state | reply_buffer: ack}}
       end)
 
-      make_call_and_assert_success(ctx, ctx.ack)
+      make_call_and_assert_success(ctx)
     end
 
     @tag port: 8170
     @tag allowed_clients: ["CLIENT-1"]
     test "accept peer cert with case mismatch", ctx do
-      make_call_and_assert_success(ctx, ctx.ack)
+      make_call_and_assert_success(ctx)
     end
 
     @tag port: 8171
@@ -735,11 +732,12 @@ defmodule ClientAndReceiverIntegrationTest do
          client_cert: "tls/client_mixed_case_cn/client_certificate.pem",
          keyfile: "tls/client_mixed_case_cn/private_key.pem"
     test "accept peer cert with mixed case CN", ctx do
-      make_call_and_assert_success(ctx, ctx.ack)
+      make_call_and_assert_success(ctx)
     end
 
-    defp make_call_and_assert_success(ctx, expected_result) do
-      assert expected_result == start_client_and_send(ctx)
+    defp make_call_and_assert_success(ctx) do
+      {:ok, :application_accept, ack} = start_client_and_send(ctx)
+      assert ack.acknowledgement_code == ctx.ack.acknowledgement_code
     end
 
     defp make_call_and_assert_failure(ctx, expected_error_reasons) do

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -224,12 +224,12 @@ defmodule ClientTest do
     test "with valid HL7 returns an AA", ctx do
       raw_hl7 = HL7.Examples.wikipedia_sample_hl7()
       message = HL7.Message.new(raw_hl7)
-      expected_ack = %MLLP.Ack{acknowledgement_code: "AA", text_message: ""}
+      expected_ack = %MLLP.Ack{acknowledgement_code: "AA"}
 
-      assert(
-        {:ok, :application_accept, expected_ack} ==
-          Client.send(ctx.client, message, %{reply_timeout: 1000})
-      )
+      {:ok, :application_accept, ack} =
+        Client.send(ctx.client, message, %{reply_timeout: 1000})
+
+      assert ack.acknowledgement_code == expected_ack.acknowledgement_code
     end
 
     test "when replies are fragmented", ctx do
@@ -237,12 +237,10 @@ defmodule ClientTest do
 
       message = HL7.Message.new(raw_hl7)
 
-      expected_ack = %MLLP.Ack{acknowledgement_code: "AA", text_message: ""}
-
       log =
         capture_log([level: :debug], fn ->
-          assert {:ok, :application_accept, expected_ack} ==
-                   Client.send(ctx.client, message)
+          {:ok, :application_accept, _ack} =
+            Client.send(ctx.client, message)
         end)
 
       fragment_log = "Client #{inspect(ctx.client)} received a MLLP fragment"


### PR DESCRIPTION
For the case where the input of `MLLP.Client.send/xx` is an `HL7.Message` struct.
The `hl7_ack_message` field is now populated with HL7.Message created from the raw response.
